### PR TITLE
fix: update existing comment to resolved with comment-mode: changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,20 @@ The option how to render changed file in comment. This action will change PR and
 - Type: String
 - Default: `"none"`
 
-The option to handle outdated comments in the PR. Available options are `none` and `minimize`. `none` do nothing. `minimize` will minimize outdated action comments.
+The option to handle outdated comments in the PR. Available options are `none`, `minimize`, and `update`.
+- `none`: Do nothing with previous comments.
+- `minimize`: Minimize (collapse) outdated action comments.
+- `update`: Edit the existing comment in place (sticky comment). When combined with `comment-mode: changes`, the existing comment will still be updated to show "resolved" when visual differences are fixed.
+
+#### `comment-mode` (Optional)
+
+- Type: String
+- Default: `"always"`
+
+When to post PR comments. Available options are `always`, `changes`, and `never`.
+- `always`: Always post a comment with the comparison results.
+- `changes`: Only post a comment when visual differences are detected. When combined with `outdated-comment-action: update`, existing comments will still be updated to show "resolved" when differences are fixed.
+- `never`: Never post PR comments (silent mode). Results are still available in the workflow summary and artifacts.
 
 ### `retention-days` (Optional)
 


### PR DESCRIPTION
## Summary
- Fixes interaction between `outdated-comment-action: update` and `comment-mode: changes`
- When there are no visual differences but an existing comment exists, it now correctly updates to show "resolved"
- Adds README documentation for `comment-mode` option and the `update` option for `outdated-comment-action`

## Problem
When using `comment-mode: changes` with `outdated-comment-action: update`, if a PR previously had visual regressions (and a comment was posted), and then those regressions were fixed, the existing comment would NOT be updated to show "resolved" - it would remain showing the old failure state.

This happened because `comment-mode: changes` was preventing ALL comment actions when there were no changes, including updating existing comments.

## Solution
Restructured the comment logic so that `comment-mode` controls whether NEW comments are posted, but existing comments are still updated to "resolved" when `outdated-comment-action: update` is set.