### PR TITLE
chore: remove unused axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
       "ansi-regex": "^6.0.1",
       "glob-parent": "^6.0.2",
       "trim-newlines": "^4.0.2",
-      "axios": "^1.1.3",
       "kind-of": "^6.0.3",
       "minimist": "^1.2.7",
       "shell-quote": "^1.7.3",
@@ -46,7 +45,6 @@
     "@bokuweb/reg-cli-wasm": "0.0.0-experimental6",
     "@types/glob": "^8.1.0",
     "adm-zip": "^0.5.16",
-    "axios": "^1.13.5",
     "chalk": "^5.6.2",
     "cpy": "^11.1.0",
     "exponential-backoff": "^3.1.3",
@@ -58,7 +56,6 @@
   "devDependencies": {
     "@octokit/openapi-types": "^22.2.0",
     "@types/adm-zip": "^0.5.7",
-    "@types/axios": "^0.14.4",
     "@types/loglevel": "^1.6.3",
     "@types/make-dir": "^2.1.0",
     "@types/node": "^22.18.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   ansi-regex: ^6.0.1
   glob-parent: ^6.0.2
   trim-newlines: ^4.0.2
-  axios: ^1.1.3
   kind-of: ^6.0.3
   minimist: ^1.2.7
   shell-quote: ^1.7.3
@@ -46,9 +45,6 @@ importers:
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
-      axios:
-        specifier: ^1.1.3
-        version: 1.13.5
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -77,9 +73,6 @@ importers:
       '@types/adm-zip':
         specifier: ^0.5.7
         version: 0.5.7
-      '@types/axios':
-        specifier: ^0.14.4
-        version: 0.14.4
       '@types/loglevel':
         specifier: ^1.6.3
         version: 1.6.3
@@ -480,10 +473,6 @@ packages:
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
 
-  '@types/axios@0.14.4':
-    resolution: {integrity: sha512-9JgOaunvQdsQ/qW2OPmE5+hCeUB52lQSolecrFrthct55QekhmXEwT203s20RL+UHtCQc15y3VXpby9E7Kkh/g==}
-    deprecated: This is a stub types definition. axios provides its own type definitions, so you do not need this installed.
-
   '@types/glob@8.1.0':
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
 
@@ -548,9 +537,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -719,15 +705,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -955,9 +932,6 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1563,12 +1537,6 @@ snapshots:
     dependencies:
       '@types/node': 22.18.12
 
-  '@types/axios@0.14.4':
-    dependencies:
-      axios: 1.13.5
-    transitivePeerDependencies:
-      - debug
-
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
@@ -1642,14 +1610,6 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
-
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   b4a@1.6.7: {}
 
@@ -1835,8 +1795,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  follow-redirects@1.15.11: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -2042,8 +2000,6 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
-
-  proxy-from-env@1.1.0: {}
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary
- `axios` is not imported anywhere in `src/` — the project uses `@actions/github` (Octokit) for HTTP.
- Removes `axios` from `dependencies`, `@types/axios` from `devDependencies`, and the `axios` entry in pnpm `overrides`.

## Test plan
- [x] `pnpm install` succeeds
- [x] `esbuild` bundle of `src/main.ts` still builds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)