### PR TITLE
ci(release): add moving `@rc-rust` preview channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+    # Moving `rc-rust` release: every push to `develop` rebuilds the
+    # binaries and force-updates the `rc-rust` tag + release so users can
+    # try the Rust port via `uses: reg-viz/reg-actions@rc-rust` without
+    # disturbing the JS-based `@rc` channel managed by deploy-rc.yml.
+    branches:
+      - develop
   workflow_dispatch:
     inputs:
       tag:
@@ -14,6 +20,12 @@ permissions:
   contents: write
   id-token: write   # for cosign keyless signing (future)
   attestations: write
+
+# Cancel in-flight develop-driven rc-rust builds when a newer commit lands.
+# Tag pushes (real releases) get unique groups so they never cancel each other.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/develop' }}
 
 jobs:
   build:
@@ -101,11 +113,30 @@ jobs:
         id: tag
         shell: bash
         run: |
+          set -euo pipefail
           if [ -n "${{ github.event.inputs.tag || '' }}" ]; then
-            echo "name=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+            name="${{ github.event.inputs.tag }}"
+            moving=false
+          elif [ "$GITHUB_REF" = "refs/heads/develop" ]; then
+            # Moving release for the Rust port preview channel.
+            name="rc-rust"
+            moving=true
           else
-            echo "name=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+            name="${GITHUB_REF##*/}"
+            moving=false
           fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "moving=$moving" >> "$GITHUB_OUTPUT"
+
+      - name: Delete previous moving release (rc-rust)
+        if: steps.tag.outputs.moving == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Best-effort cleanup so softprops can recreate the tag.
+          gh release delete "${{ steps.tag.outputs.name }}" --cleanup-tag --yes \
+            --repo "${{ github.repository }}" || true
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
@@ -131,8 +162,13 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.tag.outputs.name }}
+          # Don't promote the moving rc-rust release to "Latest".
+          make_latest: ${{ steps.tag.outputs.moving == 'true' && 'false' || 'true' }}
+          prerelease: ${{ steps.tag.outputs.moving == 'true' }}
+          name: ${{ steps.tag.outputs.moving == 'true' && 'rc-rust (preview)' || steps.tag.outputs.name }}
+          body: ${{ steps.tag.outputs.moving == 'true' && 'Moving preview release built from `develop` HEAD. Use via `uses: reg-viz/reg-actions@rc-rust` to try the Rust + wasmtime port. May break or be force-updated at any time.' || '' }}
           fail_on_unmatched_files: true
-          generate_release_notes: true
+          generate_release_notes: ${{ steps.tag.outputs.moving != 'true' }}
           files: |
             dist/*.tar.gz
             dist/checksums.txt

--- a/docs/RUST-MIGRATION.md
+++ b/docs/RUST-MIGRATION.md
@@ -105,6 +105,30 @@ verifies the keyless signature against the release workflow's OIDC identity:
 --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
 ```
 
+## Preview channel: `@rc-rust`
+
+While the legacy JS bundle continues to power `@rc` (via `deploy-rc.yml`
+pushing `dist/` to the `rc` branch), every push to `develop` also
+**force-updates** a moving GitHub Release tagged `rc-rust` containing
+fresh binaries for all 5 targets, signed with cosign keyless OIDC.
+
+Try the Rust port without disturbing existing `@rc` users:
+
+```yaml
+- uses: reg-viz/reg-actions@rc-rust
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    image-directory-path: ./screenshots
+```
+
+Notes:
+- Marked as a GitHub *prerelease* so it never appears as "Latest".
+- Tag is force-replaced (delete + recreate) on every `develop` push, so
+  pinning a SHA via Dependabot/Renovate is recommended for production
+  consumers — `@rc-rust` is for try-it-out and dogfooding only.
+- Once Phase 7 cutover lands, the regular `@rc` channel will switch to
+  the Rust binary and `@rc-rust` will be retired.
+
 ## Migration status
 
 - [x] Phase 0 — wasm protocol reverse-engineering, octocrab survey


### PR DESCRIPTION
## Summary

Adds a parallel preview channel `@rc-rust` so users can try the Rust + wasmtime port without disturbing the existing JS-based `@rc` channel managed by `deploy-rc.yml`.

| | `@rc` (existing) | `@rc-rust` (new) |
|---|---|---|
| Driven by | `deploy-rc.yml` (push `dist/` to `rc` branch) | `release.yml` on `develop` push |
| Backing | Node.js + bundled JS (`runs.using: node20`) | Rust binary downloaded from GitHub Release (`runs.using: composite`) |
| Updates | each `develop` push | each `develop` push (moving tag, force-replaced) |
| Marked | regular release | **prerelease** + `make_latest: false` |

## How it works

1. `release.yml`'s trigger now includes `branches: [develop]` in addition to `tags: [v*]`.
2. The `Determine tag` step picks `rc-rust` when `$GITHUB_REF` is `refs/heads/develop` (sets `moving=true`).
3. Before publishing, a best-effort `gh release delete rc-rust --cleanup-tag --yes` removes the previous moving release so softprops can recreate the tag at the new `develop` HEAD.
4. softprops creates a fresh prerelease with the freshly built + cosign-signed binaries.
5. The composite `action.yml` already evaluates `${{ github.action_ref }}` from `uses:`, so `@rc-rust` automatically downloads from the new release without touching `action.yml`.

`concurrency:` cancels in-flight develop builds when newer commits land. Tag pushes (real `v*` releases) never cancel each other.

## Usage after merge

```yaml
- uses: reg-viz/reg-actions@rc-rust
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    image-directory-path: ./screenshots
```

Docs added under "Preview channel: \`@rc-rust\`" in `docs/RUST-MIGRATION.md` (recommend SHA-pinning via Dependabot/Renovate if you depend on `@rc-rust` in production-ish workflows).

## Test plan

- [x] Workflow YAML syntactically valid
- [ ] Merge → first `develop` push triggers cross-build matrix → publishes `rc-rust` prerelease with binaries + checksums + cosign sig
- [ ] `uses: reg-viz/reg-actions@rc-rust` resolves `action.yml` from develop HEAD and successfully downloads + verifies the binary
- [ ] Subsequent develop push force-replaces the `rc-rust` tag and Release; previous binaries are gone

## Notes

- `@rc` is **untouched**; existing users see no change.
- This channel exists until Phase 7 cutover (when `@rc`/`@v?` switch to Rust); after that `rc-rust` will be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)