### PR TITLE
ci: supervise pnpm build with bokuweb/coronarium

### DIFF
--- a/.github/coronarium.yml
+++ b/.github/coronarium.yml
@@ -1,0 +1,53 @@
+mode: block
+
+# Mirrored from reg-viz/reg-cli — see that repo's PR for the
+# rationale on each pillar's default. Summary:
+#
+# - network: default: allow. CDN-fronted egress (Cloudflare / Fastly
+#   anycast for npm tarballs, GitHub releases) makes a strict
+#   IP-based whitelist unreachable today (rotating IPs vs. eBPF
+#   map capacity). Real defence is on the other two pillars.
+#
+# - file: default: allow + 8 deny prefixes. The 8 entries are
+#   kernel-blocked via eBPF LSM (SIGKILL on attempted reads).
+#   `default: deny` would also tag every anonymous fd open
+#   (`pipe:[…]`, `anon_inode:[…]`, …) as denied, breaking block
+#   mode despite no real violation.
+#
+# - process.deny_exec: basename block on common data-exfil /
+#   lateral-movement tools. The supervised step legitimately needs
+#   node, pnpm, sh, bash, and git — nothing on this list should
+#   ever appear in a clean run.
+
+network:
+  default: allow
+
+file:
+  default: allow
+  deny:
+    # Kernel-blocked credential / socket paths. Order matters:
+    # coronarium kernel-blocks only the first 8 entries (eBPF map
+    # capacity); the rest are tag-only and would inflate
+    # `stats.denied` without actually protecting anything.
+    - /etc/shadow
+    - /etc/sudoers
+    - /home/runner/.ssh
+    - /home/runner/.aws
+    - /home/runner/.gnupg
+    - /home/runner/.docker/config.json
+    - /var/run/docker.sock
+    - /etc/gshadow
+
+process:
+  deny_exec:
+    - curl
+    - wget
+    - nc
+    - ncat
+    - socat
+    - ssh
+    - scp
+    - sftp
+    - rsync
+    - telnet
+    - ftp

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -15,8 +15,29 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 9
-      - run: pnpm i --frozen-lockfile
-      - run: pnpm package
+
+      # Coronarium block-mode supervision around the build — same
+      # policy as the CI workflows. The `git-publish-subdir-action`
+      # below is a JavaScript action and runs in the runner agent,
+      # outside the supervised tree.
+      - uses: bokuweb/coronarium@v0
+        with:
+          policy: .github/coronarium.yml
+          mode: block
+
+      - name: pnpm i + package (coronarium block)
+        run: |
+          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
+            --policy  "$CORONARIUM_POLICY" \
+            --mode    "$CORONARIUM_MODE" \
+            --log     coronarium.log.json \
+            --html    coronarium-report.html \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            -- bash -euxo pipefail -c '
+              pnpm i --frozen-lockfile
+              pnpm package
+            '
+
       - name: deploy
         uses: s0/git-publish-subdir-action@develop
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,29 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 9
-      - run: pnpm i --frozen-lockfile
-      - run: pnpm package
+
+      # Coronarium block-mode supervision around the build — same
+      # policy as the CI workflows. The `git-publish-subdir-action`
+      # below is a JavaScript action and runs in the runner agent,
+      # outside the supervised tree.
+      - uses: bokuweb/coronarium@v0
+        with:
+          policy: .github/coronarium.yml
+          mode: block
+
+      - name: pnpm i + package (coronarium block)
+        run: |
+          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
+            --policy  "$CORONARIUM_POLICY" \
+            --mode    "$CORONARIUM_MODE" \
+            --log     coronarium.log.json \
+            --html    coronarium-report.html \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            -- bash -euxo pipefail -c '
+              pnpm i --frozen-lockfile
+              pnpm package
+            '
+
       - name: deploy
         uses: s0/git-publish-subdir-action@develop
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,11 +14,57 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 9
-      - run: pnpm i --frozen-lockfile
-      - run: pnpm package
+
+      # Audit-with-block supervision via bokuweb/coronarium. Wraps
+      # the `pnpm i + pnpm package` build under an eBPF supervisor
+      # that:
+      #   - kernel-blocks reads of credential paths
+      #     (.ssh / .aws / .gnupg / .docker / shadow / sudoers / docker.sock)
+      #   - records every exec/open/connect for the run
+      #   - fails CI if any deny-listed exec (curl/wget/nc/ssh/…)
+      #     fires inside the supervised tree.
+      # The `./dist` action step below is a JavaScript action that
+      # runs in the runner agent rather than our shell, so it sits
+      # outside the supervised tree by construction.
+      - uses: bokuweb/coronarium@v0
+        with:
+          policy: .github/coronarium.yml
+          mode: block
+
+      - name: pnpm i + package (coronarium block)
+        run: |
+          # `sudo -E env "PATH=$PATH"` so the supervised child can
+          # find pnpm; sudo strips PATH even with -E.
+          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
+            --policy  "$CORONARIUM_POLICY" \
+            --mode    "$CORONARIUM_MODE" \
+            --log     coronarium.log.json \
+            --html    coronarium-report.html \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            -- bash -euxo pipefail -c '
+              pnpm i --frozen-lockfile
+              pnpm package
+            '
+
       - uses: ./dist
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           image-directory-path: "./images"
           disable-branch: true
           report-file-path: './report.html'
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coronarium-report
+          path: |
+            coronarium-report.html
+            coronarium.log.json
+          if-no-files-found: ignore
+
+      - uses: bokuweb/coronarium/comment@v0
+        if: github.event_name == 'pull_request'
+        with:
+          log: coronarium.log.json
+          artifact-name: coronarium-report
+          html-filename: coronarium-report.html

--- a/.github/workflows/test_with_target_hash.yml
+++ b/.github/workflows/test_with_target_hash.yml
@@ -10,8 +10,30 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 9
-      - run: pnpm i --frozen-lockfile
-      - run: pnpm package
+
+      # Same coronarium block-mode supervision as test.yml — see
+      # comments there for the full rationale. Wraps `pnpm i +
+      # pnpm package` only; the JavaScript-side actions
+      # (github-script and ./dist) run in the runner agent and
+      # sit outside the supervised tree.
+      - uses: bokuweb/coronarium@v0
+        with:
+          policy: .github/coronarium.yml
+          mode: block
+
+      - name: pnpm i + package (coronarium block)
+        run: |
+          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
+            --policy  "$CORONARIUM_POLICY" \
+            --mode    "$CORONARIUM_MODE" \
+            --log     coronarium.log.json \
+            --html    coronarium-report.html \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            -- bash -euxo pipefail -c '
+              pnpm i --frozen-lockfile
+              pnpm package
+            '
+
       - uses: actions/github-script@v5
         id: target
         with:


### PR DESCRIPTION
## Summary
Adds [`bokuweb/coronarium@v0`](https://github.com/bokuweb/coronarium) supervision around the `pnpm i + pnpm package` build in all four workflows (\`test.yml\`, \`test_with_target_hash.yml\`, \`deploy.yml\`, \`deploy-rc.yml\`). Linux-only; all jobs already run on \`ubuntu-latest\`.

Coronarium attaches eBPF tracepoints + LSM hooks for the duration of the supervised command, so the build now records every \`exec\` / \`open\` / \`connect\` it makes and kernel-blocks reads of credential paths.

The JavaScript actions (\`actions/github-script\`, \`./dist\`, \`s0/git-publish-subdir-action\`) run in the runner agent rather than our shell, so they sit outside the supervised tree by construction. We supervise only the parts we run via \`run:\`.

## Policy

[\`.github/coronarium.yml\`](.github/coronarium.yml) mirrors what [reg-viz/reg-cli#650](https://github.com/reg-viz/reg-cli/pull/650) landed on:

- **network**: \`default: allow\`. CDN-fronted egress (Cloudflare / Fastly anycast for npm tarballs, GitHub releases) makes a strict IP-based whitelist unreachable today — coronarium's eBPF NET maps are sized for ~1024 entries, far smaller than the IP pools the supervised steps actually touch.
- **file**: \`default: allow\` + 8 deny prefixes (shadow / sudoers / .ssh / .aws / .gnupg / .docker / docker.sock / gshadow). Each fits in coronarium's 8 kernel-enforced LSM slots, so attempted credential reads are SIGKILL'd by the kernel.
- **process.deny_exec**: basename block on typical exfil / lateral-movement tools (curl / wget / nc / ssh / scp / rsync / telnet / ftp). The supervised steps need only node + pnpm + sh + bash + git, so anything on this list firing is signal.

## CI workflow extras

- Adds \`pull-requests: write\` permission so the PR-comment step can post.
- Adds a \`bokuweb/coronarium/comment@v0\` step so pull requests get the supervised-run report (HTML + JSON log) attached as a comment, matching the experience reg-cli rolled out.

## Test plan
- [ ] CI run on this PR is green
- [ ] PR-comment step posts a coronarium-report comment
- [ ] No spurious \`policy violation: N events denied in block mode\` failures
- [ ] Once merged, watch the next \`deploy.yml\` / \`deploy-rc.yml\` runs to confirm the build still succeeds under supervision

🤖 Generated with [Claude Code](https://claude.com/claude-code)