### PR TITLE
ci(release): publish moving `vX` major alias for stable tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,19 @@ jobs:
             name="${GITHUB_REF##*/}"
             moving=false
           fi
+
+          # For semver tag pushes (vX.Y.Z), also publish a moving major
+          # alias `vX` so users can `uses: reg-viz/reg-actions@vX` and
+          # auto-track the latest patch within that major. Pre-release
+          # tags (v4.0.0-rc1) are intentionally excluded.
+          major=""
+          if [[ "$name" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then
+            major="v${BASH_REMATCH[1]}"
+          fi
+
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "moving=$moving" >> "$GITHUB_OUTPUT"
+          echo "major=$major" >> "$GITHUB_OUTPUT"
 
       - name: Delete previous moving release (rc-rust)
         if: steps.tag.outputs.moving == 'true'
@@ -169,6 +180,45 @@ jobs:
           body: ${{ steps.tag.outputs.moving == 'true' && 'Moving preview release built from `develop` HEAD. Use via `uses: reg-viz/reg-actions@rc-rust` to try the Rust + wasmtime port. May break or be force-updated at any time.' || '' }}
           fail_on_unmatched_files: true
           generate_release_notes: ${{ steps.tag.outputs.moving != 'true' }}
+          files: |
+            dist/*.tar.gz
+            dist/checksums.txt
+            dist/checksums.txt.sig
+            dist/checksums.txt.pem
+
+      # ────────────────────────────────────────────────────────────────
+      # Moving major alias (vX) for semver releases (vX.Y.Z).
+      # Same artifacts, separate Release/tag so `uses: org/repo@vX`
+      # always resolves to the latest patch.
+      # ────────────────────────────────────────────────────────────────
+      - name: Delete previous major alias release (${{ steps.tag.outputs.major }})
+        if: steps.tag.outputs.major != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Best-effort: previous major alias may not exist yet (first vX.0.0).
+          gh release delete "${{ steps.tag.outputs.major }}" --cleanup-tag --yes \
+            --repo "${{ github.repository }}" || true
+
+      - name: Publish moving major alias release (${{ steps.tag.outputs.major }})
+        if: steps.tag.outputs.major != ''
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ steps.tag.outputs.major }}
+          target_commitish: ${{ github.sha }}
+          # The canonical vX.Y.Z release stays "Latest"; the moving alias
+          # piggybacks on the same artifacts but doesn't override it.
+          make_latest: false
+          prerelease: false
+          name: ${{ steps.tag.outputs.major }} (moving alias)
+          body: |
+            Moving alias for the latest `${{ steps.tag.outputs.major }}.x.y` release.
+            Currently points at [`${{ steps.tag.outputs.name }}`](https://github.com/${{ github.repository }}/releases/tag/${{ steps.tag.outputs.name }}).
+
+            Use via `uses: reg-viz/reg-actions@${{ steps.tag.outputs.major }}` to auto-track patches.
+            For reproducible builds, pin the canonical tag or a SHA.
+          fail_on_unmatched_files: true
           files: |
             dist/*.tar.gz
             dist/checksums.txt

--- a/docs/RUST-MIGRATION.md
+++ b/docs/RUST-MIGRATION.md
@@ -129,6 +129,53 @@ Notes:
 - Once Phase 7 cutover lands, the regular `@rc` channel will switch to
   the Rust binary and `@rc-rust` will be retired.
 
+## Cutting `v4` (the first stable Rust release)
+
+Once `@rc-rust` validation is satisfactory, promote it to a stable
+`v4` major channel as follows:
+
+1. **Merge `develop` → `main`** so the Rust port is on the stable line.
+
+2. **Tag and push** a semver release from `main`:
+
+   ```sh
+   git switch main && git pull
+   git tag -a v4.0.0 -m "v4.0.0: Rust + wasmtime port"
+   git push origin v4.0.0
+   ```
+
+3. `release.yml` triggers on the `v*` tag and runs **two release jobs
+   in one workflow**:
+   - **Canonical release** at `v4.0.0` — marked `make_latest: true`,
+     full release notes, cosign-signed checksums, SLSA attestation.
+   - **Moving major alias** at `v4` — same binaries, `make_latest:
+     false`, short body that links back to the canonical tag. The
+     existing `v4` tag/release (if any) is force-replaced first.
+
+4. Users can then choose:
+
+   ```yaml
+   - uses: reg-viz/reg-actions@v4         # auto-track v4.x.y
+   - uses: reg-viz/reg-actions@v4.0.0     # pin exact patch
+   - uses: reg-viz/reg-actions@<sha>      # reproducible (Dependabot/Renovate friendly)
+   ```
+
+5. Subsequent patch releases (`v4.0.1`, `v4.1.0`, …) re-run the same
+   workflow and re-point `v4` at the new SHA. Pre-release tags
+   (`v4.1.0-rc1`) intentionally do **not** move the major alias; they
+   live at their own tag only.
+
+6. **Retire the legacy channels** in a follow-up PR:
+   - delete `dist/`, `package.json`, `pnpm-lock.yaml`, `tsconfig.json`,
+     `src/*.ts`
+   - delete `.github/workflows/{deploy,deploy-rc,test,test_with_target_hash}.yml`
+   - delete the `rc-rust` Release & tag (now superseded by `@v4`)
+   - update the README "v1/v2 are deprecated" warning to "v3 is
+     deprecated; please use v4".
+
+The legacy `@v3` branch keeps working until step 6 is shipped, so
+existing consumers see no break during the cutover.
+
 ## Migration status
 
 - [x] Phase 0 — wasm protocol reverse-engineering, octocrab survey


### PR DESCRIPTION
## Summary

Adds a moving `vX` GitHub Release whenever a semver tag (`vX.Y.Z`) is pushed, so users can write `uses: reg-viz/reg-actions@v4` and auto-track patches — the same pattern actions/checkout, sigstore/cosign-installer, etc. expose.

## Why

Once `@rc-rust` validation looks good, cutting `v4` should be a one-command tag push. Without this PR, only the canonical `v4.0.0` release would exist and `uses: reg-viz/reg-actions@v4` would 404 on the binary download (no `v4` Release).

## What changes

In [`release.yml`](https://github.com/reg-viz/reg-actions/blob/chore/release-major-alias/.github/workflows/release.yml):

1. `Determine tag` step: regex `^v([0-9]+)\.[0-9]+\.[0-9]+$` extracts the major (`v4` from `v4.0.0`). Pre-release tags like `v4.0.0-rc1` intentionally don't match — moving aliases only track stable releases.
2. After the canonical `vX.Y.Z` Release is published, two extra steps run when `major` is non-empty:
   - `gh release delete vX --cleanup-tag --yes` (best-effort) so the old alias goes away cleanly
   - softprops creates a fresh `vX` Release with `make_latest: false` (canonical `vX.Y.Z` stays "Latest"), short body linking back to the canonical tag, and the same artifacts (binaries + cosign-signed checksums)

The composite `action.yml` already evaluates `\${{ github.action_ref }}` to whatever the user wrote in `uses:`, so **no action.yml changes are needed** — `@v4` resolves to the moving Release; `@v4.0.0` to the canonical one; both contain byte-identical binaries.

## After this lands, the v4 cutover is

```sh
git switch main && git pull   # after merging develop → main
git tag -a v4.0.0 -m "v4.0.0: Rust + wasmtime port"
git push origin v4.0.0
# → release.yml publishes both v4.0.0 (canonical, Latest) and v4 (moving alias)
```

`docs/RUST-MIGRATION.md` gets a new **Cutting `v4` (the first stable Rust release)** section with the full procedure including the legacy-channel retirement checklist (delete `dist/`, `package.json`, legacy workflows, and the `rc-rust` Release once `@v4` is live).

## Test plan

- [x] YAML syntactically valid
- [x] Regex matches `v4.0.0` → major=v4; doesn't match `v4.0.0-rc1`, `rc-rust`, `v123-anything`
- [ ] After merge → push a throw-away `v0.0.1` tag from a scratch branch to verify both Releases get created (canonical + `v0` alias) without disturbing rc-rust or anything else; then `gh release delete v0 v0.0.1 --cleanup-tag --yes` to clean up
- [ ] On real `v4.0.0` push (later): both `v4.0.0` and `v4` Releases land; `make_latest` is set correctly; cosign signatures + SLSA attestation present on the canonical
- [ ] `uses: reg-viz/reg-actions@v4` resolves and runs end-to-end

## Notes

- The canonical release keeps `generate_release_notes: true`. The moving alias gets a hand-written body so the auto-notes don't get duplicated.
- SLSA attestation is generated once on the canonical release (binaries are byte-identical between `vX.Y.Z` and `vX`, so attestation-by-hash covers both).
- Pre-existing `@rc` (JS) and `@rc-rust` channels are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)