### PR TITLE
ci: rename coronarium → sakimori and use the new one-step `run:` input

### DIFF
--- a/.github/sakimori.yml
+++ b/.github/sakimori.yml
@@ -26,7 +26,7 @@ file:
   default: allow
   deny:
     # Kernel-blocked credential / socket paths. Order matters:
-    # coronarium kernel-blocks only the first 8 entries (eBPF map
+    # sakimori kernel-blocks only the first 8 entries (eBPF map
     # capacity); the rest are tag-only and would inflate
     # `stats.denied` without actually protecting anything.
     - /etc/shadow

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -16,27 +16,20 @@ jobs:
         with:
           version: 9
 
-      # Coronarium block-mode supervision around the build — same
+      # Sakimori block-mode supervision around the build — same
       # policy as the CI workflows. The `git-publish-subdir-action`
       # below is a JavaScript action and runs in the runner agent,
       # outside the supervised tree.
-      - uses: bokuweb/coronarium@v0
+      - name: pnpm i + package (sakimori block)
+        uses: bokuweb/sakimori@v0
         with:
-          policy: .github/coronarium.yml
+          policy: .github/sakimori.yml
           mode: block
-
-      - name: pnpm i + package (coronarium block)
-        run: |
-          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
-            --policy  "$CORONARIUM_POLICY" \
-            --mode    "$CORONARIUM_MODE" \
-            --log     coronarium.log.json \
-            --html    coronarium-report.html \
-            --summary "$GITHUB_STEP_SUMMARY" \
-            -- bash -euxo pipefail -c '
-              pnpm i --frozen-lockfile
-              pnpm package
-            '
+          log: sakimori.log.json
+          html: sakimori-report.html
+          run: |
+            pnpm i --frozen-lockfile
+            pnpm package
 
       - name: deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,27 +16,20 @@ jobs:
         with:
           version: 9
 
-      # Coronarium block-mode supervision around the build — same
+      # Sakimori block-mode supervision around the build — same
       # policy as the CI workflows. The `git-publish-subdir-action`
       # below is a JavaScript action and runs in the runner agent,
       # outside the supervised tree.
-      - uses: bokuweb/coronarium@v0
+      - name: pnpm i + package (sakimori block)
+        uses: bokuweb/sakimori@v0
         with:
-          policy: .github/coronarium.yml
+          policy: .github/sakimori.yml
           mode: block
-
-      - name: pnpm i + package (coronarium block)
-        run: |
-          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
-            --policy  "$CORONARIUM_POLICY" \
-            --mode    "$CORONARIUM_MODE" \
-            --log     coronarium.log.json \
-            --html    coronarium-report.html \
-            --summary "$GITHUB_STEP_SUMMARY" \
-            -- bash -euxo pipefail -c '
-              pnpm i --frozen-lockfile
-              pnpm package
-            '
+          log: sakimori.log.json
+          html: sakimori-report.html
+          run: |
+            pnpm i --frozen-lockfile
+            pnpm package
 
       - name: deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: 9
 
-      # Audit-with-block supervision via bokuweb/coronarium. Wraps
+      # Audit-with-block supervision via bokuweb/sakimori. Wraps
       # the `pnpm i + pnpm package` build under an eBPF supervisor
       # that:
       #   - kernel-blocks reads of credential paths
@@ -26,25 +26,20 @@ jobs:
       # The `./dist` action step below is a JavaScript action that
       # runs in the runner agent rather than our shell, so it sits
       # outside the supervised tree by construction.
-      - uses: bokuweb/coronarium@v0
+      #
+      # The action's new `run:` input (sakimori v0.33+) wraps the
+      # script with `sakimori run` for us — no separate
+      # `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run …` step needed.
+      - name: pnpm i + package (sakimori block)
+        uses: bokuweb/sakimori@v0
         with:
-          policy: .github/coronarium.yml
+          policy: .github/sakimori.yml
           mode: block
-
-      - name: pnpm i + package (coronarium block)
-        run: |
-          # `sudo -E env "PATH=$PATH"` so the supervised child can
-          # find pnpm; sudo strips PATH even with -E.
-          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
-            --policy  "$CORONARIUM_POLICY" \
-            --mode    "$CORONARIUM_MODE" \
-            --log     coronarium.log.json \
-            --html    coronarium-report.html \
-            --summary "$GITHUB_STEP_SUMMARY" \
-            -- bash -euxo pipefail -c '
-              pnpm i --frozen-lockfile
-              pnpm package
-            '
+          log: sakimori.log.json
+          html: sakimori-report.html
+          run: |
+            pnpm i --frozen-lockfile
+            pnpm package
 
       - uses: ./dist
         with:
@@ -56,15 +51,15 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: coronarium-report
+          name: sakimori-report
           path: |
-            coronarium-report.html
-            coronarium.log.json
+            sakimori-report.html
+            sakimori.log.json
           if-no-files-found: ignore
 
-      - uses: bokuweb/coronarium/comment@v0
+      - uses: bokuweb/sakimori/comment@v0
         if: github.event_name == 'pull_request'
         with:
-          log: coronarium.log.json
-          artifact-name: coronarium-report
-          html-filename: coronarium-report.html
+          log: sakimori.log.json
+          artifact-name: sakimori-report
+          html-filename: sakimori-report.html

--- a/.github/workflows/test_with_target_hash.yml
+++ b/.github/workflows/test_with_target_hash.yml
@@ -11,28 +11,21 @@ jobs:
         with:
           version: 9
 
-      # Same coronarium block-mode supervision as test.yml — see
+      # Same sakimori block-mode supervision as test.yml — see
       # comments there for the full rationale. Wraps `pnpm i +
       # pnpm package` only; the JavaScript-side actions
       # (github-script and ./dist) run in the runner agent and
       # sit outside the supervised tree.
-      - uses: bokuweb/coronarium@v0
+      - name: pnpm i + package (sakimori block)
+        uses: bokuweb/sakimori@v0
         with:
-          policy: .github/coronarium.yml
+          policy: .github/sakimori.yml
           mode: block
-
-      - name: pnpm i + package (coronarium block)
-        run: |
-          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
-            --policy  "$CORONARIUM_POLICY" \
-            --mode    "$CORONARIUM_MODE" \
-            --log     coronarium.log.json \
-            --html    coronarium-report.html \
-            --summary "$GITHUB_STEP_SUMMARY" \
-            -- bash -euxo pipefail -c '
-              pnpm i --frozen-lockfile
-              pnpm package
-            '
+          log: sakimori.log.json
+          html: sakimori-report.html
+          run: |
+            pnpm i --frozen-lockfile
+            pnpm package
 
       - uses: actions/github-script@v5
         id: target


### PR DESCRIPTION
## Summary
- The supply-chain guard repo was renamed from [bokuweb/coronarium](https://github.com/bokuweb/sakimori) to [bokuweb/sakimori](https://github.com/bokuweb/sakimori). Rename the policy file (`.github/coronarium.yml` → `.github/sakimori.yml`), action refs, env-var references (`CORONARIUM_*` → `SAKIMORI_*`), and the log/report artefact names so CI keeps working against the new home.
- Take advantage of sakimori v0.33's new `run:` input across all four workflows (`test.yml`, `deploy.yml`, `deploy-rc.yml`, `test_with_target_hash.yml`) — the action installs sakimori AND wraps the script under `sakimori run` for us, so the explicit `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run …` step collapses into the action invocation itself.

Before (each workflow):
```yaml
- uses: bokuweb/coronarium@v0
  with:
    policy: .github/coronarium.yml
    mode: block
- name: pnpm i + package (coronarium block)
  run: |
    sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
      --policy  "$CORONARIUM_POLICY" \
      --mode    "$CORONARIUM_MODE" \
      --log     coronarium.log.json \
      --html    coronarium-report.html \
      --summary "$GITHUB_STEP_SUMMARY" \
      -- bash -euxo pipefail -c '
        pnpm i --frozen-lockfile
        pnpm package
      '
```

After:
```yaml
- name: pnpm i + package (sakimori block)
  uses: bokuweb/sakimori@v0
  with:
    policy: .github/sakimori.yml
    mode: block
    log: sakimori.log.json
    html: sakimori-report.html
    run: |
      pnpm i --frozen-lockfile
      pnpm package
```

Net change: `+49 / -75` across 5 files.

## Test plan
- [ ] `test.yml` green on this PR (Linux block-mode supervised, `bokuweb/sakimori/comment@v0` posts a comment, `sakimori-report` artefact uploaded).
- [ ] `test_with_target_hash.yml` green on this PR.
- [ ] `deploy.yml` / `deploy-rc.yml` only run on main / develop pushes after merge — verify on the first push following merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)