### PR TITLE
ci: use `bokuweb/sakimori/job/stop@v0` sub-action for mid-job flush

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,17 +42,12 @@ jobs:
           disable-branch: true
           report-file-path: './report.html'
 
-      # Force the daemon to flush its log + HTML mid-job so the
-      # upload-artifact / comment steps below can see them. The
-      # job-action's post-hook also calls `daemon stop`, but it runs
-      # at the very end of the job — long after upload-artifact has
-      # already executed. `daemon stop` is idempotent on a missing
-      # pid-file, so the post-hook becomes a no-op.
+      # Flush the daemon so upload-artifact + the comment sub-action
+      # below see the freshly-written log + HTML. The daemon's own
+      # post-hook would otherwise write them at end-of-job, too late
+      # for an in-job upload.
       - if: always()
-        name: Flush sakimori daemon
-        run: |
-          sudo -n -E "$SAKIMORI_BIN" daemon stop \
-            --pid-file "$SAKIMORI_JOB_PIDFILE"
+        uses: bokuweb/sakimori/job/stop@v0
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
sakimori v0.34.4 shipped a 1-line sub-action that wraps the verbose `daemon stop` snippet we had inlined here (https://github.com/bokuweb/sakimori/pull/64).

**Before**
```yaml
- if: always()
  name: Flush sakimori daemon
  run: |
    sudo -n -E "$SAKIMORI_BIN" daemon stop \
      --pid-file "$SAKIMORI_JOB_PIDFILE"
```

**After**
```yaml
- if: always()
  uses: bokuweb/sakimori/job/stop@v0
```

Same semantics — idempotent on a missing pid-file, no-op on non-Linux runners. Only `test.yml` needs the change; `test_with_target_hash.yml` doesn't upload artifacts so it never needed the flush in the first place. `deploy*.yml` are still on the one-step composite form and don't have a daemon to stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)