### PR TITLE
fix(release): repair YAML parse error blocking the rc-rust release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             os: ubuntu-latest
             cross: true
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-14
           - target: x86_64-pc-windows-msvc
@@ -166,7 +166,10 @@ jobs:
           make_latest: ${{ steps.tag.outputs.moving == 'true' && 'false' || 'true' }}
           prerelease: ${{ steps.tag.outputs.moving == 'true' }}
           name: ${{ steps.tag.outputs.moving == 'true' && 'rc-rust (preview)' || steps.tag.outputs.name }}
-          body: ${{ steps.tag.outputs.moving == 'true' && 'Moving preview release built from `develop` HEAD. Use via `uses: reg-viz/reg-actions@rc-rust` to try the Rust + wasmtime port. May break or be force-updated at any time.' || '' }}
+          # Block scalar so the inline literal — which contains `uses: ` —
+          # parses as a YAML string, not a nested mapping.
+          body: |-
+            ${{ steps.tag.outputs.moving == 'true' && 'Moving preview release built from `develop` HEAD. Use via `uses: reg-viz/reg-actions@rc-rust` to try the Rust + wasmtime port. May break or be force-updated at any time.' || '' }}
           fail_on_unmatched_files: true
           generate_release_notes: ${{ steps.tag.outputs.moving != 'true' }}
           files: |


### PR DESCRIPTION
## Why `@rc-rust` 404s

`release.yml` has been **silently failing on every trigger** since PR #207 landed — every run shows up in Actions as "This run likely failed because of a workflow file issue" with zero jobs and an empty \`jobs[]\` array. That's the classic symptom of a YAML parse error that aborts before the workflow can be scheduled, so no \`rc-rust\` Release has ever actually been created.

actionlint pins the bug to one line in \`.github/workflows/release.yml\`:

\`\`\`
release.yml:180:122: could not parse as YAML:
mapping values are not allowed in this context [syntax-check]
        body: ${{ ... 'Use via \`uses: reg-viz/reg-actions@rc-rust\` ...' ... }}
                                                                  ^~
\`\`\`

The inline expression contains \`uses: reg-viz\` as a literal substring. YAML reads the outer \`body:\` as an unquoted scalar that runs to end-of-line, then sees the inner \`uses: \` (colon + space) and tries to interpret it as a nested mapping — which is illegal in this position, so the whole file is rejected.

## Fix

Two bugs, both in this PR:

1. **Block scalar for \`body:\`** — wraps the templated value in a \`|-\` block scalar so the colon-space inside the conditional string stays inert. The result is still a single-line string after expression evaluation; \`|-\` strips the trailing newline.

2. **macos-13 → macos-15-intel** — \`macos-13\` is no longer in the GitHub-hosted runner label set (actionlint flags it as \`unknown\`). \`macos-15-intel\` is the current x86_64-macOS option; arm64 stays on \`macos-14\`. Even with the YAML fix above, the matrix would have failed scheduling and the dependent \`release\` job would have been skipped, so this hidden-second-bug also has to go for any Release to actually publish.

\`actionlint\` is now clean across all three Rust workflows.

## Expected after merge

1. Merging this PR pushes a commit to \`develop\`.
2. \`release.yml\` parses successfully, triggers the 5-target matrix build (~10–15 min).
3. The \`release\` job's \`Delete previous moving release (rc-rust)\` step is a no-op (no prior Release exists), then softprops creates the first \`rc-rust\` prerelease with binaries + checksums + cosign signature.
4. \`uses: reg-viz/reg-actions@rc-rust\` finally resolves.

## Test plan

- [x] \`actionlint .github/workflows/release.yml .github/workflows/rust.yml .github/workflows/rust-self-test.yml\` clean (exit 0)
- [x] Diff is minimal: 1 file, 5+/2- lines, no behavioural change beyond unblocking the workflow
- [ ] After merge → \`release.yml\` actually completes on the develop push
- [ ] \`gh release view rc-rust --repo reg-viz/reg-actions\` shows assets including \`reg-actions-x86_64-unknown-linux-gnu.tar.gz\` etc.
- [ ] A trivial sample workflow using \`reg-viz/reg-actions@rc-rust\` no longer errors with "unable to find version"

## Heads up

The follow-on PR for the moving \`vX\` major alias ([#209](https://github.com/reg-viz/reg-actions/pull/209)) is built on top of the broken develop tip, so it inherited the same YAML bug in the same line. Once this PR lands and #209 rebases, the major-alias logic will also be reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)