### PR TITLE
fix(release): unblock aarch64-linux + windows matrix targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,19 +56,29 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
-      - name: Install cross (linux aarch64)
+      # Native cross-compile for aarch64-linux via apt's gcc cross-toolchain.
+      # We previously used `cargo install cross --rev v0.2.5`, but that
+      # pinned revision no longer builds on modern Rust (soundness
+      # diagnostics for `&mut` to mutable statics — 18 errors in
+      # cross::temp). Going through apt + a target-specific linker keeps
+      # the supply-chain surface flat (no third-party cargo install).
+      - name: Install aarch64 cross-toolchain (linux aarch64)
         if: ${{ matrix.cross }}
-        run: cargo install cross --git https://github.com/cross-rs/cross --rev v0.2.5
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          {
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc"
+            echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc"
+            echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar"
+          } >> "$GITHUB_ENV"
 
       - name: Build
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${{ matrix.cross || '' }}" ]; then
-            cross build --release --target ${{ matrix.target }} --bin reg-actions
-          else
-            cargo build --release --target ${{ matrix.target }} --bin reg-actions
-          fi
+          cargo build --release --target ${{ matrix.target }} --bin reg-actions
 
       - name: Package
         shell: bash
@@ -77,15 +87,17 @@ jobs:
           ext='${{ matrix.ext }}'
           out="reg-actions-${{ matrix.target }}.tar.gz"
           tar czf "$out" -C "target/${{ matrix.target }}/release" "reg-actions${ext}"
-          shasum -a 256 "$out" > "$out.sha256"
+          # Per-target .sha256 is no longer emitted here: the release job
+          # regenerates a combined `checksums.txt` from the uploaded
+          # tar.gz files, and Windows runners' Git Bash doesn't ship
+          # `shasum`/`sha256sum` by default. Avoiding the redundant
+          # hashing here keeps the matrix portable.
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bin-${{ matrix.target }}
-          path: |
-            reg-actions-${{ matrix.target }}.tar.gz
-            reg-actions-${{ matrix.target }}.tar.gz.sha256
+          path: reg-actions-${{ matrix.target }}.tar.gz
 
   release:
     needs: build


### PR DESCRIPTION
## Why \`@rc-rust\` is still 404 after #213

PR #213 fixed the YAML parse error, so the latest run ([25725432503](https://github.com/reg-viz/reg-actions/actions/runs/25725432503)) finally **scheduled jobs** — but 2 of 5 matrix targets failed, which kept the dependent \`release\` job in a skipped state, so no Release was created.

\`\`\`
✅ build (x86_64-unknown-linux-gnu)
❌ build (aarch64-unknown-linux-gnu)   ← cross v0.2.5 fails to compile on Rust 1.95
✅ build (x86_64-apple-darwin)
✅ build (aarch64-apple-darwin)
❌ build (x86_64-pc-windows-msvc)      ← \`shasum\` not on Git-Bash-on-Windows
⏭️ release                              ← skipped (needs: build had failures)
\`\`\`

## Failure 1 — aarch64-linux: \`cross\` doesn't build anymore

\`cargo install cross --git https://github.com/cross-rs/cross --rev v0.2.5\` (from 2023) hits 18 fresh soundness errors on modern rustc:

\`\`\`
error: creating a mutable reference to mutable static
   --> src/temp.rs:90:5
\`\`\`

…and bails out before we can build anything.

**Fix**: drop \`cross\` entirely. Use apt's \`gcc-aarch64-linux-gnu\` cross-toolchain and let cargo do the cross-build natively. Three env vars wire cargo to the cross linker/AR/CC; the build step then collapses to a plain \`cargo build --release --target …\` for all 5 targets.

This is also a small supply-chain win: one fewer \`cargo install\` from a moving git revision.

## Failure 2 — windows: \`shasum\` not found

\`\`\`
D:\\a\\_temp\\….sh: line 5: shasum: command not found
##[error]Process completed with exit code 127.
\`\`\`

The Package step generated a per-target \`.sha256\` sidecar via \`shasum -a 256\`, which is only reliably present on Linux + macOS, not on Windows Git-Bash.

**Fix**: drop the sidecar entirely. The \`release\` job already regenerates a unified \`checksums.txt\` from the uploaded \`.tar.gz\` files, so the per-target file was redundant. Removing it also shrinks the upload artifact and removes the only non-portable shell call in the matrix.

## Test plan

- [x] \`actionlint .github/workflows/release.yml\` clean
- [x] Diff minimal: 1 file, +23 / -11 lines
- [ ] After merge → \`release.yml\` runs, **all 5 matrix targets succeed**, \`release\` job runs and creates the first \`rc-rust\` prerelease with binaries + checksums + cosign signature
- [ ] \`gh release view rc-rust --repo reg-viz/reg-actions\` lists 5 \`.tar.gz\` assets
- [ ] \`uses: reg-viz/reg-actions@rc-rust\` resolves the action.yml from develop HEAD and successfully downloads + verifies the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)