### PR TITLE
fix(release): pin rc-rust tag to workflow commit, not default branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,14 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.tag.outputs.name }}
+          # Pin the tag to the workflow's actual commit. Without this,
+          # softprops omits target_commitish, the GitHub API falls back
+          # to `repository.default_branch` (= main), and a tag created
+          # from a develop push would resolve to a main commit that
+          # doesn't yet contain action.yml at the root — making
+          # `uses: org/repo@rc-rust` fail with
+          # "Can't find 'action.yml' for action".
+          target_commitish: ${{ github.sha }}
           # Don't promote the moving rc-rust release to "Latest".
           make_latest: ${{ steps.tag.outputs.moving == 'true' && 'false' || 'true' }}
           prerelease: ${{ steps.tag.outputs.moving == 'true' }}


### PR DESCRIPTION
## Why \`@rc-rust\` still fails after #213 + #214

#213 fixed the YAML parse error → workflow finally scheduled.
#214 fixed the cross-compile and Windows hashing → all 5 matrix targets went green.

The latest [run #25731187413](https://github.com/reg-viz/reg-actions/actions/runs/25731187413) **succeeded** and created the rc-rust Release with all five \`.tar.gz\` assets. But consumers still see:

\`\`\`
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile'
for action 'reg-viz/reg-actions@rc-rust'.
\`\`\`

…because the tag landed on the **wrong commit**:

\`\`\`
$ git ls-tree --name-only rc-rust | grep -E '^(action.yml|Cargo.toml)'
# (nothing)

$ git show --no-patch --format='%H %s' rc-rust
7bcfef248b3e0d2440aaca65f3ce032009f85443 ci: use \`bokuweb/sakimori/job/stop@v0\` sub-action for mid-job flush (#212)

$ git branch -r --contains 7bcfef24
  origin/main
\`\`\`

That's a **main** commit (the legacy JS line), which only has \`dist/action.yml\` — not a root \`action.yml\`. So checking out \`@rc-rust\` lands on a tree without an action manifest.

## Root cause

When softprops/action-gh-release is called without \`target_commitish\`, it omits the field in its API call. The GitHub Releases API then defaults that field to \`repository.default_branch\` (= \`main\`), so the freshly created \`rc-rust\` tag points at \`main\` HEAD — even though the workflow was triggered by a \`develop\` push.

The matching \`Publish moving major alias release\` step (added in #209 / not yet merged but in this file) already specifies \`target_commitish: \${{ github.sha }}\`, so this fix simply brings the two softprops invocations into agreement.

## Fix

One-line addition to the \`Create GitHub Release\` step:

\`\`\`yaml
target_commitish: \${{ github.sha }}
\`\`\`

Now the tag is pinned to the exact commit that triggered the workflow (the develop HEAD that contains the Rust port + root \`action.yml\`).

The \`Delete previous moving release\` step that already runs before softprops takes care of removing the misplaced tag on the next run, so no manual cleanup is required — merging this PR triggers a new develop push, which deletes the wrong-SHA rc-rust and recreates it at the right one.

## Test plan

- [x] \`actionlint\` clean
- [x] Diff: 1 file, +8 / -0 lines (8 lines because of the explanatory comment)
- [ ] After merge → new release.yml run on develop → \`gh release view rc-rust\` shows the tag SHA matches develop HEAD
- [ ] \`git ls-tree --name-only rc-rust | head\` shows \`action.yml\`, \`Cargo.toml\`, \`vendor/\` etc.
- [ ] Sample workflow with \`uses: reg-viz/reg-actions@rc-rust\` resolves and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)