### PR TITLE
fix(action.yml): keep canonical archive filename so `shasum -c` finds the file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,16 +87,20 @@ runs:
         target='${{ steps.target.outputs.target }}'
         ext='${{ steps.target.outputs.ext }}'
         base="https://github.com/reg-viz/reg-actions/releases/download/${ver}"
-        url="${base}/reg-actions-${target}.tar.gz"
+        archive="reg-actions-${target}.tar.gz"
+        url="${base}/${archive}"
         sums="${base}/checksums.txt"
         workdir="$RUNNER_TEMP/reg-actions-bin"
         mkdir -p "$workdir"
         cd "$workdir"
         echo "Downloading ${url}"
-        curl --proto '=https' --tlsv1.2 -fsSL "$url" -o reg-actions.tar.gz
+        # Save the archive under its canonical name so `shasum -c` can
+        # match the path listed in checksums.txt (which contains
+        # entries like `<sha>  reg-actions-<target>.tar.gz`).
+        curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$archive"
         curl --proto '=https' --tlsv1.2 -fsSL "$sums" -o checksums.txt
         # SHA256 verification (always)
-        grep " reg-actions-${target}.tar.gz$" checksums.txt | shasum -a 256 -c -
+        grep " ${archive}$" checksums.txt | shasum -a 256 -c -
         # Optional cosign keyless signature verification.
         # If cosign is on PATH, attempt to verify checksums.txt against the
         # release workflow's OIDC identity. Failures here are fatal — once
@@ -114,7 +118,7 @@ runs:
         else
           echo '::notice::cosign not found on PATH; skipping signature verification (sha256 still verified). Install sigstore/cosign-installer in your workflow to enable.'
         fi
-        tar xzf reg-actions.tar.gz
+        tar xzf "$archive"
         chmod +x "reg-actions${ext}"
         echo "REG_ACTIONS_BIN=$workdir/reg-actions${ext}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Why \`@rc-rust\` still 500s after the release pipeline went green

#213 → #214 → #215 unblocked the release.yml pipeline; the latest run on develop publishes a proper rc-rust prerelease with binaries at the right SHA. But the first end-to-end \`uses: reg-viz/reg-actions@rc-rust\` attempt fails inside our own action.yml's verification step:

\`\`\`
Downloading https://github.com/reg-viz/reg-actions/releases/download/rc-rust/reg-actions-x86_64-unknown-linux-gnu.tar.gz
shasum: reg-actions-x86_64-unknown-linux-gnu.tar.gz: No such file or directory
reg-actions-x86_64-unknown-linux-gnu.tar.gz: FAILED open or read
shasum: WARNING: 1 listed file could not be read
Error: Process completed with exit code 1.
\`\`\`

## Root cause

The download step renames the tarball during download:

\`\`\`bash
curl ... "$url" -o reg-actions.tar.gz                              # <- short local name
grep " reg-actions-${target}.tar.gz$" checksums.txt | shasum -a 256 -c -
\`\`\`

But \`checksums.txt\` lists entries by their **full per-target name**:

\`\`\`
<sha256>  reg-actions-x86_64-unknown-linux-gnu.tar.gz
\`\`\`

\`grep …\` pipes that one line into \`shasum -c\`. \`shasum -c\` parses the line as \`<expected-hash> <space> <filename>\` and tries to open the file at \`<filename>\` — which is \`reg-actions-x86_64-unknown-linux-gnu.tar.gz\` on disk. That file doesn't exist because we'd saved it as \`reg-actions.tar.gz\` on the previous line. Hence the open-or-read failure.

## Fix

Keep the canonical filename throughout the step. One \`archive=\` variable drives the curl \`-o\`, the grep pattern, and the final \`tar xzf\`:

\`\`\`bash
archive="reg-actions-${target}.tar.gz"
url="${base}/${archive}"
...
curl ... "$url" -o "$archive"
curl ... "$sums" -o checksums.txt
grep " ${archive}$" checksums.txt | shasum -a 256 -c -
...
tar xzf "$archive"
\`\`\`

No behaviour change beyond making \`shasum -c\` find the file it's supposed to verify. \`tar xzf\` doesn't care about the filename — it just needs a valid gzip stream.

## Test plan

- [x] Diff: 1 file, +8 / -4 lines
- [ ] After merge → release.yml on develop publishes rc-rust with the fixed action.yml at the rc-rust tag (no rebuild needed — the action.yml change is what consumers fetch)
- [ ] \`uses: reg-viz/reg-actions@rc-rust\` succeeds through download + verify + extract on linux x86_64 (and ideally the other 4 targets via rust-self-test or a manual probe)

## Heads up

This is the **fourth follow-up** in the rc-rust thread (after #213/#214/#215). The class of bug is "the release pipeline was never reaching the consumer side before, so consumer-side bugs are surfacing one-by-one now that the binaries actually exist." Once this lands and a consumer workflow gets all the way through, I'd expect the remaining issues — if any — to be in Artifact v4 upload (real GitHub runtime testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)