### PR TITLE
fix(client): follow 302 on artifact download, silence noisy upload error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,6 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use backon::{ExponentialBuilder, Retryable};
 use bytes::Bytes;
-use http_body_util::BodyExt;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -137,22 +136,26 @@ impl ApiClient {
     }
 
     /// Workflow run artifact を zip でダウンロードする (REST API 経由)。
+    ///
+    /// `/repos/{}/actions/artifacts/{}/zip` は **302 で Azure Blob 署名 URL
+    /// にリダイレクト**する仕様なので、生の `_get` だと空ボディが返って
+    /// `Could not find EOCD` で zip パースに失敗する。
+    /// octocrab の `actions().download_artifact()` は内部で
+    /// `follow_location_to_data` を呼んで本体を取りに行ってくれるので、
+    /// そちらを経由する。
     pub async fn download_artifact_zip(&self, artifact_id: u64) -> Result<Bytes> {
+        use octocrab::params::actions::ArchiveFormat;
         let owner = self.repository.owner.clone();
         let repo = self.repository.repo.clone();
         let octo = self.octocrab.clone();
-        let url = format!("/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip");
-        let resp = (|| async { octo._get(url.clone()).await })
-            .retry(Self::backoff())
-            .await
-            .context("downloadArtifact")?;
-        // フォロー先 URL の本体を取得
-        let bytes = resp
-            .into_body()
-            .collect()
-            .await
-            .context("collect download body")?
-            .to_bytes();
+        let bytes = (|| async {
+            octo.actions()
+                .download_artifact(&owner, &repo, artifact_id.into(), ArchiveFormat::Zip)
+                .await
+        })
+        .retry(Self::backoff())
+        .await
+        .context("downloadArtifact")?;
         Ok(bytes)
     }
 
@@ -340,9 +343,15 @@ impl ArtifactClient {
     /// Artifact をアップロードする。
     /// `files` のうち `workspace_root` 配下にあるものだけをアーカイブし、相対パスで保存。
     ///
-    /// **本実装は Phase 2 stub**: 実 GitHub Actions ランナー上での動作確認が
-    /// 別途必要。現状は protocol に沿った API 呼び出しを行うが、エラーハンドリング・
-    /// チャンク分割・SHA256 計算は最小限。
+    /// **既知の制約 (2026-05 時点):** Artifact v4 の Twirl API は
+    /// `ACTIONS_RUNTIME_TOKEN` / `ACTIONS_RESULTS_URL` を要求するが、
+    /// これらは **composite action のシェルステップには runner が注入しない**
+    /// (GitHub のセキュリティ仕様)。Node20 action からは process env で
+    /// 見えるが、composite からは見えない。
+    ///
+    /// 当面は env 変数が無いときに `Ok(skipped)` を返してアップロードを
+    /// no-op 扱いとする。次回比較のための expected 画像保存は、別ルート
+    /// (reg_actions branch への push) でカバーされる前提。
     pub async fn upload_artifact(
         &self,
         artifact_name: &str,
@@ -350,10 +359,13 @@ impl ArtifactClient {
         workspace_root: &Path,
     ) -> Result<UploadArtifactResult> {
         if !self.enabled() {
-            anyhow::bail!(
-                "Artifact API is unavailable (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL not set). \
-                 Are you running outside a GitHub Actions runner?"
+            tracing::warn!(
+                "skipping artifact upload — ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL not \
+                 available to this composite step. The branch-based image storage \
+                 (`disable-branch: false`) still works; only the artifact-as-cache path is \
+                 affected. Tracking: https://github.com/actions/runner/issues/2391",
             );
+            return Ok(UploadArtifactResult { id: None, size: 0 });
         }
 
         // 1. zip を作る

--- a/src/service.rs
+++ b/src/service.rs
@@ -219,7 +219,7 @@ async fn compare_and_upload(client: &ApiClient, config: &Config) -> Result<Compa
             r.id
         }
         Err(e) => {
-            tracing::error!(error = %e, "upload_artifact failed");
+            tracing::warn!(error = %e, "upload_artifact failed (non-fatal)");
             None
         }
     };


### PR DESCRIPTION
## Why \"everything was detected as new\"

First real end-to-end run of \`uses: reg-viz/reg-actions@rc-rust\` on a consumer PR shows:

\`\`\`
INFO found target run target_run_id=25723976470
INFO downloading expected images artifact_id=6939879828
INFO downloaded zip size=0
ERROR open zip failed error=invalid Zip archive: Could not find EOCD
__REG_CLI_EVT__ {\"path\":\"...\",\"type\":\"new\"}   × 167
\`\`\`

Root cause: \`GET /repos/{}/actions/artifacts/{}/zip\` returns a **302 Found** redirect to a signed Azure Blob URL. Our code did:

\`\`\`rust
let resp = octocrab._get(url).await?;
let bytes = resp.into_body().collect().await?.to_bytes();   // empty
\`\`\`

\`_get\` doesn't follow the redirect, so the body is the 302 response itself (empty), \`zip::ZipArchive::new\` immediately fails with \`Could not find EOCD\`, \`download_expected_images\` swallows the error, and every actual image ends up classified as \"new\".

## Fix

Octocrab already provides \`actions().download_artifact()\` which calls its own \`follow_location_to_data\` helper to perform the second GET against the redirect target. Swap our hand-rolled call for that:

\`\`\`rust
let bytes = octo
    .actions()
    .download_artifact(&owner, &repo, artifact_id.into(), ArchiveFormat::Zip)
    .await?;
\`\`\`

This re-enables the \"download last successful run's images, classify diffs against them\" path that the JS implementation has always had.

## Secondary fix: stop yelling about Artifact upload

The same log shows:

\`\`\`
ERROR upload_artifact failed error=Artifact API is unavailable
  (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL not set).
  Are you running outside a GitHub Actions runner?
\`\`\`

This is **not actually an error** — it's a known limitation of running as a composite action. The runner deliberately omits \`ACTIONS_RUNTIME_*\` env vars from composite-action shell environments for security (see [actions/runner#2391](https://github.com/actions/runner/issues/2391)). Node20 / Docker actions get them; composites do not.

Until we add a tiny JS shim to forward those env vars (separate PR), the artifact-as-cache path is unusable when running as a composite. The push-to-branch image storage (default \`disable-branch: false\`) **still works**, so PR comments and branch-based diffs continue to function — only the next-run \"find target artifact via REST API\" optimization is degraded.

Changes:
- \`upload_artifact\`: when env vars are missing, log a single \`warn!\` and return \`Ok(UploadArtifactResult { id: None, size: 0 })\` instead of \`bail!\`-ing
- service.rs: \`tracing::error!\` → \`tracing::warn!\` on upload failure, with \"(non-fatal)\" suffix

## Test plan

- [x] \`cargo test --all\` — 17 unit + 2 e2e tests still pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] release binary builds cleanly
- [ ] After merge → rerunning the consumer workflow should download the prior artifact correctly. Comparison output should match what \`@v3\` (the JS implementation) reports for the same PR.
- [ ] The \`ERROR upload_artifact failed\` line in the consumer log becomes a single \`WARN\`-level note linking to the runner issue.

## On the user's secondary question — \"Rust 版のほうがセキュア\"

Yes, in the architectural sense: smaller dep surface (\`Cargo.lock\` pins ~25 direct crates vs 17 npm + hundreds transitive), reg.wasm SHA256-pinned in \`build.rs\`, single signed binary with cosign + SLSA. **But** this PR is the fourth follow-up after merging — i.e. the implementation has been chasing real-world bugs that the JS line had already solved. The security posture is better; the runtime maturity isn't there yet. Once the Artifact API forwarding (composite limitation) and the rust-self-test workflow have shipped a few green runs, the maturity gap should close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)