### PR TITLE
fix(compare): bump wasmtime linear memory caps to wasm32 max

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -183,6 +183,19 @@ pub fn run_compare(input: &CompareInput) -> Result<CompareOutput> {
     // Engine: wasi-threads が要求する threads サポートを ON
     let mut wcfg = WasmConfig::new();
     wcfg.wasm_threads(true);
+    // 大きな画像 (高解像度 PNG など) を扱うと reg.wasm 内の dlmalloc が
+    // 数百 MB 単位の連続領域を要求し、デフォルトのメモリ予約サイズでは
+    // memory.grow に失敗して `unreachable` トラップを起こすケースがある。
+    // wasm32 の linear memory 上限である 4 GiB まで予約を引き上げ、
+    // guard も最大化することで、モジュールが宣言する max まで素直に
+    // 伸ばせるようにする。
+    // 実効上限は reg.wasm 側の `(memory ... max)` 宣言 (現在 1 GiB) が
+    // 律速するため、それ以上必要な場合は wasm 側の再ビルドが必要。
+    const WASM32_MAX: u64 = 1 << 32; // 4 GiB
+    wcfg.static_memory_maximum_size(WASM32_MAX);
+    wcfg.static_memory_guard_size(WASM32_MAX);
+    wcfg.dynamic_memory_guard_size(WASM32_MAX);
+    wcfg.dynamic_memory_reserved_for_growth(WASM32_MAX);
     let engine = Engine::new(&wcfg).context("create wasmtime engine")?;
 
     let module = Module::new(&engine, REG_WASM).context("compile reg.wasm")?;


### PR DESCRIPTION
## Summary

大判 PNG (高解像度 docx レンダリング結果など) を扱った際、reg.wasm 内で
```
memory allocation of 260995200 bytes failed
...
Caused by: wasm trap: wasm `unreachable` instruction executed
```
というクラッシュが GitHub Actions 上で再現していました。

これは reg.wasm 内の dlmalloc が数百 MB の連続領域を要求して `memory.grow` を呼ぶ際、wasmtime 側のデフォルトのメモリ予約 / guard サイズによって grow が拒否され、Rust の alloc error → `unreachable` トラップに至っていたものです。

このPRでは wasmtime の `Config` のメモリ関連パラメータを **wasm32 linear memory の上限 (4 GiB)** までまとめて引き上げ、wasmtime 側が律速にならないようにします。

- `static_memory_maximum_size` → 4 GiB
- `static_memory_guard_size` → 4 GiB
- `dynamic_memory_guard_size` → 4 GiB
- `dynamic_memory_reserved_for_growth` → 4 GiB

## Notes

- 実効上限は依然として **reg.wasm 側の `(memory ... max=16384)` = 1 GiB** が律速します。これを超える解像度のケースでは wasm 自体の再ビルド (or 画像処理側のメモリ削減) が必要です。
- shared memory 経路 (`wasi-threads`) では wasmtime は static memory を使うため、主に効くのは `static_memory_*` 側ですが、念のため dynamic 側も同値に揃えました。

## Test plan

- [ ] `cargo check` 通過 (ローカル確認済み)
- [ ] `cargo test` で既存テスト緑
- [ ] rc-rust リリース後、報告された PR (jlsi/document-editor #4254) のシナリオで OOM が出ないこと